### PR TITLE
feat: add bastion host for database access and update VPC configuration

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -13,5 +13,8 @@ const env = {
 const envName: string =
   app.node.tryGetContext("env") ?? process.env.ENV_NAME ?? "dev";
 
-new DatabaseStack(app, "skorifyDatabase", { env, envName });
-new MatchProcessingStack(app, "skorifyEventBridge", { env, envName });
+const vpcName: string =
+  app.node.tryGetContext("vpcName") ?? `skorify-${envName}-vpc`;
+
+new DatabaseStack(app, `skorify-database-${envName}`, { env, envName, vpcName });
+// new MatchProcessingStack(app, "skorifyEventBridge", { env, envName });

--- a/infra/lib/constructs/db-migrations.ts
+++ b/infra/lib/constructs/db-migrations.ts
@@ -54,7 +54,7 @@ export class DbMigrations extends Construct {
       // Migraciones pueden tardar en DBs frías; 2 min es suficiente margen
       timeout: cdk.Duration.minutes(2),
       vpc,
-      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
       environment: {
         DB_SECRET_ARN: dbSecretArn,
         DB_NAME: dbName,

--- a/infra/lib/db-stack.ts
+++ b/infra/lib/db-stack.ts
@@ -1,16 +1,16 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
 import * as rds from 'aws-cdk-lib/aws-rds';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as events from 'aws-cdk-lib/aws-events';
 import { RdsScheduler } from './constructs/rds-scheduler';
 import { DbMigrations } from './constructs/db-migrations';
-import { isProduction } from '../utils/conditionals';
 
 export interface DatabaseStackProps extends cdk.StackProps {
   envName: string;
-  env: Record<string, any>;
+  vpcName: string;
 }
 
 export class DatabaseStack extends cdk.Stack {
@@ -19,29 +19,15 @@ export class DatabaseStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: DatabaseStackProps) {
     super(scope, id, props);
 
-    const { envName, env } = props;
-
-    // const vpcName = ssm.StringParameter.valueFromLookup(
-    //   this,
-    //   `/skorify/${envName}/vpc-name`,
-    // );
-    // const dbSecurityGroupId = ssm.StringParameter.valueFromLookup(
-    //   this,
-    //   `/skorify/${envName}/db-sg-id`,
-    // );
-
-    const vpcName = "skorify-dev-vpc";
-
-    const dbSecurityGroupId = "sg-03ff86270c4f7cf97";
+    const { envName, vpcName } = props;
 
     const vpc = ec2.Vpc.fromLookup(this, 'ImportedVPC', { vpcName });
 
-    const dbSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
-      this,
-      'ImportedDBSecurityGroup',
-      dbSecurityGroupId,
-      { mutable: true },
-    );
+    const dbSecurityGroup = new ec2.SecurityGroup(this, 'DBSecurityGroup', {
+      vpc,
+      description: 'Security group for Skorify RDS instance',
+      allowAllOutbound: false,
+    });
 
     dbSecurityGroup.addIngressRule(
       ec2.Peer.ipv4(vpc.vpcCidrBlock),
@@ -49,19 +35,57 @@ export class DatabaseStack extends cdk.Stack {
       'Allow internal connections from the VPC',
     );
 
+    // ── Bastion host (ASG) ───────────────────────────────────────────────────
+    const bastionSecurityGroup = new ec2.SecurityGroup(this, 'BastionSecurityGroup', {
+      vpc,
+      description: 'Security group for Skorify bastion host',
+      allowAllOutbound: true,
+    });
+
+    bastionSecurityGroup.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(22),
+      'Allow SSH from anywhere (restrict to your IP in production)',
+    );
+
+    // Allow the bastion to reach RDS
+    dbSecurityGroup.addIngressRule(
+      ec2.Peer.securityGroupId(bastionSecurityGroup.securityGroupId),
+      ec2.Port.tcp(5432),
+      'Allow connections from bastion host',
+    );
+
+    const bastionAsg = new autoscaling.AutoScalingGroup(this, 'BastionAsg', {
+      vpc,
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
+      machineImage: ec2.MachineImage.latestAmazonLinux2023(),
+      securityGroup: bastionSecurityGroup,
+      vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+      keyPair: ec2.KeyPair.fromKeyPairName(this, 'BastionKeyPair', `skorify-${envName}-bastion`),
+      minCapacity: 0,
+      maxCapacity: 1,
+      desiredCapacity: 1,
+    });
+
+    new cdk.CfnOutput(this, 'BastionAsgName', {
+      value: bastionAsg.autoScalingGroupName,
+      description: 'Bastion ASG name — set desired=0 to stop, desired=1 to start',
+    });
+    // ─────────────────────────────────────────────────────────────────────────
+
     this.database = new rds.DatabaseInstance(this, 'skorifyDatabase', {
       engine: rds.DatabaseInstanceEngine.postgres({ version: rds.PostgresEngineVersion.VER_18 }),
       instanceType: ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.MICRO),
       vpc,
       securityGroups: [dbSecurityGroup], 
       vpcSubnets: { 
-        subnetType: ec2.SubnetType.PRIVATE_ISOLATED // no se si es isolated o  whit egress
+        subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS
       },
       databaseName: 'skorify',
       removalPolicy: cdk.RemovalPolicy.SNAPSHOT, 
     });
 
-    if (!isProduction) {
+    if (envName !== 'pdn') {
       new RdsScheduler(this, 'RdsScheduler', {
         databaseInstance: this.database,
         startSchedule: events.Schedule.cron({ minute: '0', hour: '12', weekDay: 'MON-FRI' }),

--- a/infra/pnpm-workspace.yaml
+++ b/infra/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - "."
+
 allowBuilds:
   skorifydata: true


### PR DESCRIPTION
- Refactor `DatabaseStack` to use dynamic VPC lookup
- Create a new security group instead of using an existing one
- Integrate bastion host access for database connectivity