### PR TITLE
feat: update subnet types and integrate CI environment for database m…

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -6,15 +6,19 @@ import { MatchProcessingStack } from "../lib/match-processing-stack";
 const app = new cdk.App();
 
 const env = {
-  account: process.env.CDK_DEFAULT_ACCOUNT,
-  region: process.env.CDK_DEFAULT_REGION,
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
 };
 
 const envName: string =
-  app.node.tryGetContext("env") ?? process.env.ENV_NAME ?? "dev";
+    app.node.tryGetContext("env") ?? process.env.ENV_NAME ?? "dev";
 
 const vpcName: string =
-  app.node.tryGetContext("vpcName") ?? `skorify-${envName}-vpc`;
+    app.node.tryGetContext("vpcName") ?? `skorify-${ envName }-vpc`;
 
-new DatabaseStack(app, `skorify-database-${envName}`, { env, envName, vpcName });
-// new MatchProcessingStack(app, "skorifyEventBridge", { env, envName });
+
+const backendUrl =
+    app.node.tryGetContext("backendUrl") ?? process.env.BACKEND_URL ?? "";
+
+new DatabaseStack(app, `skorify-database-${ envName }`, { env, envName, vpcName });
+new MatchProcessingStack(app, `skorify-event-bridge-${ envName }`, { env, envName, vpcName, backendUrl });

--- a/infra/cdk.context.json
+++ b/infra/cdk.context.json
@@ -1,1 +1,50 @@
-{}
+{
+  "env": "prod",
+  "vpcName": "skorify-prod-vpc",
+  "backendUrl": "https://api.skorify.cloud-manizales.com",
+  "vpc-provider:account=151646410766:filter.tag:Name=skorify-pdn-vpc:region=us-east-1:returnAsymmetricSubnets=true": {
+    "vpcId": "vpc-08506af24531f2dcb",
+    "vpcCidrBlock": "10.0.0.0/16",
+    "ownerAccountId": "151646410766",
+    "availabilityZones": [],
+    "subnetGroups": [
+      {
+        "name": "Private",
+        "type": "Private",
+        "subnets": [
+          {
+            "subnetId": "subnet-0fb86eedc4fda34e0",
+            "cidr": "10.0.1.0/24",
+            "availabilityZone": "us-east-1a",
+            "routeTableId": "rtb-07f0f03d734cede19"
+          },
+          {
+            "subnetId": "subnet-005725c5264f50f50",
+            "cidr": "10.0.2.0/24",
+            "availabilityZone": "us-east-1b",
+            "routeTableId": "rtb-07f0f03d734cede19"
+          }
+        ]
+      },
+      {
+        "name": "Public",
+        "type": "Public",
+        "subnets": [
+          {
+            "subnetId": "subnet-0e8c94f2c585c8eab",
+            "cidr": "10.0.101.0/24",
+            "availabilityZone": "us-east-1a",
+            "routeTableId": "rtb-04844137d1a9485fb"
+          },
+          {
+            "subnetId": "subnet-0aa47d82c019aef44",
+            "cidr": "10.0.102.0/24",
+            "availabilityZone": "us-east-1b",
+            "routeTableId": "rtb-04844137d1a9485fb"
+          }
+        ]
+      }
+    ]
+  },
+  "ssm:account=151646410766:parameterName=/skorify/pdn/db-secret-arn:region=us-east-1": "arn:aws:secretsmanager:us-east-1:151646410766:secret:skorifyDatabaseSecretEE7B60-z9Frbk0i73Nl-pXLmxc"
+}

--- a/infra/lib/constructs/createMatchesFlow.ts
+++ b/infra/lib/constructs/createMatchesFlow.ts
@@ -55,7 +55,7 @@ export class createMatchesFlow extends Construct {
       runtime: LAMBDA_DEFAULTS.runtime,
       timeout: LAMBDA_DEFAULTS.timeout,
       vpc: props.vpc,
-      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
       environment: {
         DB_SECRET_ARN: props.dbSecretArn,
         TOURNAMENT_MAPPING_TABLE: this.tournamentMappingTable.tableName,
@@ -76,7 +76,7 @@ export class createMatchesFlow extends Construct {
       runtime: LAMBDA_DEFAULTS.runtime,
       timeout: LAMBDA_DEFAULTS.timeout,
       vpc: props.vpc,
-      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
       environment: {
         DB_SECRET_ARN: props.dbSecretArn,
         TEAM_MAPPING_TABLE: this.teamMappingTable.tableName,
@@ -97,7 +97,7 @@ export class createMatchesFlow extends Construct {
       runtime: LAMBDA_DEFAULTS.runtime,
       timeout: LAMBDA_DEFAULTS.timeout,
       vpc: props.vpc,
-      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
       environment: {
         DB_SECRET_ARN: props.dbSecretArn,
         MATCH_MAPPING_TABLE: this.matchMappingTable.tableName,

--- a/infra/lib/constructs/db-migrations.ts
+++ b/infra/lib/constructs/db-migrations.ts
@@ -68,6 +68,8 @@ export class DbMigrations extends Construct {
         externalModules: [
           'mysql', 'mysql2', 'sqlite3', 'better-sqlite3', 'tedious', 'oracledb', 'pg-native',
         ],
+        // CI=true tells pnpm to skip the interactive TTY confirmation when purging node_modules
+        environment: { CI: 'true' },
         commandHooks: {
           beforeBundling: () => [],
           beforeInstall: () => [],

--- a/infra/lib/match-processing-stack.ts
+++ b/infra/lib/match-processing-stack.ts
@@ -26,6 +26,8 @@ import { SharedResources } from "./constructs/shared-resources";
 
 export interface MatchProcessingStackProps extends cdk.StackProps {
   envName: string;
+  vpcName: string;
+  backendUrl: string;
 }
 
 export class MatchProcessingStack extends cdk.Stack {
@@ -34,14 +36,7 @@ export class MatchProcessingStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: MatchProcessingStackProps) {
     super(scope, id, props);
 
-    const { envName } = props;
-
-    // const vpcName = ssm.StringParameter.valueFromLookup(
-    //   this,
-    //   `/skorify/${envName}/vpc-name`,
-    // );
-
-    const vpcName = "skorify-dev-vpc";
+    const { envName, vpcName, backendUrl } = props;
 
     const dbSecretArn = ssm.StringParameter.valueFromLookup(
       this,
@@ -49,10 +44,6 @@ export class MatchProcessingStack extends cdk.Stack {
     );
 
     const vpc = ec2.Vpc.fromLookup(this, "ImportedVpc", { vpcName });
-    const backendUrl =
-      this.node.tryGetContext("backendUrl") ??
-      process.env.BACKEND_URL ??
-      "";
 
     const sharedResources = new SharedResources(this, "SharedResources", { envName });
 

--- a/infra/lib/networking-stack.ts
+++ b/infra/lib/networking-stack.ts
@@ -33,7 +33,7 @@ export class NetworkingStack extends cdk.Stack {
       subnetConfiguration: [
         {
           name: 'isolated',
-          subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+          subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
           cidrMask: 24,
         },
       ],


### PR DESCRIPTION
…igrations

- Change subnet types from `PRIVATE_ISOLATED` to `PRIVATE_WITH_EGRESS`
- Add `CI=true` environment variable to streamline database migration commands
- Enhance VPC configuration with `vpcName` and `backendUrl` parameters
- Update `MatchProcessingStack` to use dynamic `vpcName` and `backendUrl`