### PR TITLE
feat: update subnet types and integrate CI environment for database m…

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -6,15 +6,19 @@ import { MatchProcessingStack } from "../lib/match-processing-stack";
 const app = new cdk.App();
 
 const env = {
-  account: process.env.CDK_DEFAULT_ACCOUNT,
-  region: process.env.CDK_DEFAULT_REGION,
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
 };
 
 const envName: string =
-  app.node.tryGetContext("env") ?? process.env.ENV_NAME ?? "dev";
+    app.node.tryGetContext("env") ?? process.env.ENV_NAME ?? "dev";
 
 const vpcName: string =
-  app.node.tryGetContext("vpcName") ?? `skorify-${envName}-vpc`;
+    app.node.tryGetContext("vpcName") ?? `skorify-${ envName }-vpc`;
 
-new DatabaseStack(app, `skorify-database-${envName}`, { env, envName, vpcName });
-// new MatchProcessingStack(app, "skorifyEventBridge", { env, envName });
+
+const backendUrl =
+    app.node.tryGetContext("backendUrl") ?? process.env.BACKEND_URL ?? "";
+
+new DatabaseStack(app, `skorify-database-${ envName }`, { env, envName, vpcName });
+new MatchProcessingStack(app, `skorify-event-bridge-${ envName }`, { env, envName, vpcName, backendUrl });

--- a/infra/lib/constructs/createMatchesFlow.ts
+++ b/infra/lib/constructs/createMatchesFlow.ts
@@ -55,7 +55,7 @@ export class createMatchesFlow extends Construct {
       runtime: LAMBDA_DEFAULTS.runtime,
       timeout: LAMBDA_DEFAULTS.timeout,
       vpc: props.vpc,
-      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
       environment: {
         DB_SECRET_ARN: props.dbSecretArn,
         TOURNAMENT_MAPPING_TABLE: this.tournamentMappingTable.tableName,
@@ -76,7 +76,7 @@ export class createMatchesFlow extends Construct {
       runtime: LAMBDA_DEFAULTS.runtime,
       timeout: LAMBDA_DEFAULTS.timeout,
       vpc: props.vpc,
-      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
       environment: {
         DB_SECRET_ARN: props.dbSecretArn,
         TEAM_MAPPING_TABLE: this.teamMappingTable.tableName,
@@ -97,7 +97,7 @@ export class createMatchesFlow extends Construct {
       runtime: LAMBDA_DEFAULTS.runtime,
       timeout: LAMBDA_DEFAULTS.timeout,
       vpc: props.vpc,
-      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
       environment: {
         DB_SECRET_ARN: props.dbSecretArn,
         MATCH_MAPPING_TABLE: this.matchMappingTable.tableName,

--- a/infra/lib/constructs/db-migrations.ts
+++ b/infra/lib/constructs/db-migrations.ts
@@ -68,6 +68,8 @@ export class DbMigrations extends Construct {
         externalModules: [
           'mysql', 'mysql2', 'sqlite3', 'better-sqlite3', 'tedious', 'oracledb', 'pg-native',
         ],
+        // CI=true tells pnpm to skip the interactive TTY confirmation when purging node_modules
+        environment: { CI: 'true' },
         commandHooks: {
           beforeBundling: () => [],
           beforeInstall: () => [],

--- a/infra/lib/match-processing-stack.ts
+++ b/infra/lib/match-processing-stack.ts
@@ -26,6 +26,8 @@ import { SharedResources } from "./constructs/shared-resources";
 
 export interface MatchProcessingStackProps extends cdk.StackProps {
   envName: string;
+  vpcName: string;
+  backendUrl: string;
 }
 
 export class MatchProcessingStack extends cdk.Stack {
@@ -34,14 +36,7 @@ export class MatchProcessingStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: MatchProcessingStackProps) {
     super(scope, id, props);
 
-    const { envName } = props;
-
-    // const vpcName = ssm.StringParameter.valueFromLookup(
-    //   this,
-    //   `/skorify/${envName}/vpc-name`,
-    // );
-
-    const vpcName = "skorify-dev-vpc";
+    const { envName, vpcName, backendUrl } = props;
 
     const dbSecretArn = ssm.StringParameter.valueFromLookup(
       this,
@@ -49,10 +44,6 @@ export class MatchProcessingStack extends cdk.Stack {
     );
 
     const vpc = ec2.Vpc.fromLookup(this, "ImportedVpc", { vpcName });
-    const backendUrl =
-      this.node.tryGetContext("backendUrl") ??
-      process.env.BACKEND_URL ??
-      "";
 
     const sharedResources = new SharedResources(this, "SharedResources", { envName });
 

--- a/infra/lib/networking-stack.ts
+++ b/infra/lib/networking-stack.ts
@@ -33,7 +33,7 @@ export class NetworkingStack extends cdk.Stack {
       subnetConfiguration: [
         {
           name: 'isolated',
-          subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+          subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
           cidrMask: 24,
         },
       ],


### PR DESCRIPTION
…igrations

- Change subnet types from `PRIVATE_ISOLATED` to `PRIVATE_WITH_EGRESS`
- Add `CI=true` environment variable to streamline database migration commands
- Enhance VPC configuration with `vpcName` and `backendUrl` parameters
- Update `MatchProcessingStack` to use dynamic `vpcName` and `backendUrl`

# Conflicts:
#	infra/cdk.context.json