### PR TITLE
ci: orden de deploy (database antes que event-bridge)

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -65,6 +65,11 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DATA_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
+      # Orden importante: database primero (publica /skorify/dev/db-secret-arn),
+      # luego event-bridge (que lo lee). En un entorno fresco no se puede
+      # desplegar --all porque el event-bridge lo resuelve en synth-time.
       - name: CDK deploy (env=dev)
         working-directory: infra
-        run: pnpm exec cdk deploy --all --context env=dev --require-approval never
+        run: |
+          pnpm exec cdk deploy skorify-database-dev --context env=dev --require-approval never
+          pnpm exec cdk deploy skorify-event-bridge-dev --context env=dev --require-approval never

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -65,6 +65,11 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DATA_DEPLOY_ROLE_ARN_PROD }}
           aws-region: ${{ env.AWS_REGION }}
 
+      # Orden importante: database primero (publica /skorify/prod/db-secret-arn),
+      # luego event-bridge (que lo lee). En un entorno fresco no se puede
+      # desplegar --all porque el event-bridge lo resuelve en synth-time.
       - name: CDK deploy (env=prod)
         working-directory: infra
-        run: pnpm exec cdk deploy --all --context env=prod --require-approval never
+        run: |
+          pnpm exec cdk deploy skorify-database-prod --context env=prod --require-approval never
+          pnpm exec cdk deploy skorify-event-bridge-prod --context env=prod --require-approval never


### PR DESCRIPTION
El event-bridge necesita el db-secret-arn que publica el database. En un entorno fresco `cdk deploy --all` falla, así que se separa en deploy secuencial: primero database, luego event-bridge.