### PR TITLE
perf(infra): dimensiona la RDS por entorno

### DIFF
--- a/infra/lib/db-stack.ts
+++ b/infra/lib/db-stack.ts
@@ -75,7 +75,10 @@ export class DatabaseStack extends cdk.Stack {
 
     this.database = new rds.DatabaseInstance(this, 'skorifyDatabase', {
       engine: rds.DatabaseInstanceEngine.postgres({ version: rds.PostgresEngineVersion.VER_18 }),
-      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.MICRO),
+      instanceType: ec2.InstanceType.of(
+        ec2.InstanceClass.T4G,
+        envName === 'prod' ? ec2.InstanceSize.MEDIUM : ec2.InstanceSize.SMALL,
+      ),
       vpc,
       securityGroups: [dbSecurityGroup], 
       vpcSubnets: { 


### PR DESCRIPTION
 t4g.small dev, t4g.medium prod

La db.t4g.micro agotó sus créditos de CPU el 3 de junio y llegó a 70 de ~110 conexiones máximas con tráfico de desarrollo. Se sube la instancia según el entorno de cara al pico de tráfico del Mundial.

El cambio de clase de instancia implica una breve indisponibilidad (single-AZ) mientras RDS aplica la modificación.