### PR TITLE
perf(infra): asigna memoria por entorno a las lambdas del flujo de partidos (512MB dev, 1024MB prod)

### DIFF
--- a/infra/lib/constructs/createMatchesFlow.ts
+++ b/infra/lib/constructs/createMatchesFlow.ts
@@ -19,6 +19,7 @@ export interface CreateMatchesFlowProps {
   matchMappingTable: dynamodb.Table;
   teamMappingTable: dynamodb.Table;
   tournamentMappingTable: dynamodb.Table;
+  memorySize: number;
 }
 
 export class createMatchesFlow extends Construct {
@@ -44,7 +45,8 @@ export class createMatchesFlow extends Construct {
     this.matchesByCompetitionLambda = createLambda(
       "GetMatchesByCompetitionLambda",
       path.join(__dirname, '..', '..', 'lambdas', 'create-tournament', 'get-matches-by-competition.ts'),
-      this
+      this,
+      props.memorySize
     );
 
     this.matchesByCompetitionLambda.addEnvironment("FOOTBALL_DATA_API_TOKEN", process.env.FOOTBALL_DATA_API_TOKEN || '');
@@ -54,6 +56,7 @@ export class createMatchesFlow extends Construct {
       handler: 'handler',
       runtime: LAMBDA_DEFAULTS.runtime,
       timeout: LAMBDA_DEFAULTS.timeout,
+      memorySize: props.memorySize,
       vpc: props.vpc,
       vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
       environment: {
@@ -75,6 +78,7 @@ export class createMatchesFlow extends Construct {
       handler: 'handler',
       runtime: LAMBDA_DEFAULTS.runtime,
       timeout: LAMBDA_DEFAULTS.timeout,
+      memorySize: props.memorySize,
       vpc: props.vpc,
       vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
       environment: {
@@ -96,6 +100,7 @@ export class createMatchesFlow extends Construct {
       handler: 'handler',
       runtime: LAMBDA_DEFAULTS.runtime,
       timeout: LAMBDA_DEFAULTS.timeout,
+      memorySize: props.memorySize,
       vpc: props.vpc,
       vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
       environment: {

--- a/infra/lib/match-processing-stack.ts
+++ b/infra/lib/match-processing-stack.ts
@@ -35,6 +35,8 @@ export class MatchProcessingStack extends cdk.Stack {
 
     const { envName, vpcName, backendUrl } = props;
 
+    const lambdaMemorySize = envName === 'prod' ? 1024 : 512;
+
     const dbSecretArn = ssm.StringParameter.valueFromLookup(
       this,
       `/skorify/${envName}/db-secret-arn`,
@@ -89,7 +91,7 @@ export class MatchProcessingStack extends cdk.Stack {
     const notifyUserQueue = createQueue("NotifyUserQueue");
     const calculateRankingQueue = createQueue("CalculateRankingQueue");
 
-    const workerLambda = createLambda("WorkerLambda", "lambdas/etl-process/worker.ts", this);
+    const workerLambda = createLambda("WorkerLambda", "lambdas/etl-process/worker.ts", this, lambdaMemorySize);
     workerLambda.addEnvironment("EVENT_BUS_NAME", this.bus.eventBusName);
     workerLambda.addEnvironment("MATCH_MAPPING_TABLE", matchMappingTable.tableName);
     workerLambda.addEnvironment("TOURNAMENT_MAPPING_TABLE", tournamentMappingTable.tableName);
@@ -101,7 +103,8 @@ export class MatchProcessingStack extends cdk.Stack {
     const finishMatchLambda = createLambda(
       "FinishMatchLambda",
       "lambdas/etl-process/finish-match.ts",
-      this
+      this,
+      lambdaMemorySize
     );
     finishMatchLambda.addEnvironment(ENV.BACKEND_URL, backendUrl);
     finishMatchLambda.addEnvironment(ENV.M2M_SECRET_ARN, m2mCredentialsSecretArn);
@@ -228,12 +231,13 @@ export class MatchProcessingStack extends cdk.Stack {
       ],
     });
 
-    new createMatchesFlow(this, "CreateMatchesFlow", { 
+    new createMatchesFlow(this, "CreateMatchesFlow", {
       vpc,
       dbSecretArn,
       matchMappingTable,
       teamMappingTable,
-      tournamentMappingTable
+      tournamentMappingTable,
+      memorySize: lambdaMemorySize
     });
   }
 }

--- a/infra/lib/utils.ts
+++ b/infra/lib/utils.ts
@@ -3,10 +3,11 @@ import { LAMBDA_DEFAULTS } from "./constants";
 import { Construct } from "constructs";
 
 
-export const createLambda = (name: string, entry: string, cls: Construct): nodejs.NodejsFunction =>
+export const createLambda = (name: string, entry: string, cls: Construct, memorySize?: number): nodejs.NodejsFunction =>
     new nodejs.NodejsFunction(cls, name, {
         entry,
         handler: "handler",
         runtime: LAMBDA_DEFAULTS.runtime,
         timeout: LAMBDA_DEFAULTS.timeout,
+        memorySize,
     });


### PR DESCRIPTION
## Qué cambia
Asigna memoria explícita a las lambdas del flujo de procesamiento de partidos, con el mismo esquema por entorno que el backend: **512 MB en dev y 1024 MB en prod**.

- `WorkerLambda` y `FinishMatchLambda` (match-processing-stack)
- Las 4 lambdas del `CreateMatchesFlow` (get-matches, resolve-tournament, resolve-teams, save-matches)
- `createLambda` en `utils.ts` acepta ahora un `memorySize` opcional

`NotifyUsersLambda` y `CalculateRankingLambda` quedan en el default de 128 MB porque están holgadas (74 MB usados, p99 de 120 ms).

## Por qué
Medición de 14 días en CloudWatch (logs REPORT):
- **WorkerLambda usaba el 100% de sus 128 MB** con ~6.000 invocaciones — mismo síntoma de presión de memoria que tenía el backend antes de subirlo a 512 MB.
- **FinishMatch y las del CreateMatchesFlow usaban 104–108 MB de 128** — margen muy justo, y FinishMatch orquesta el flujo pesado de cierre de partido con timeout de 30 s.

## Validación
- `tsc` compila y `cdk synth` genera 6 funciones con `MemorySize: 512` en dev y `1024` en prod.
- Tras el deploy, comparar en Logs Insights: `filter @type = "REPORT" | stats pct(@duration,99), max(@maxMemoryUsed/1000000) by @log` — el `maxMemoryUsed` del Worker debería despegarse del techo.