### PR TITLE
feat(infra): tópico SNS de alertas operativas y alarmas de RDS

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -20,5 +20,11 @@ const vpcName: string =
 const backendUrl =
     app.node.tryGetContext("backendUrl") ?? process.env.BACKEND_URL ?? "";
 
-new DatabaseStack(app, `skorify-database-${ envName }`, { env, envName, vpcName });
-new MatchProcessingStack(app, `skorify-event-bridge-${ envName }`, { env, envName, vpcName, backendUrl });
+const databaseStack = new DatabaseStack(app, `skorify-database-${ envName }`, { env, envName, vpcName });
+new MatchProcessingStack(app, `skorify-event-bridge-${ envName }`, {
+    env,
+    envName,
+    vpcName,
+    backendUrl,
+    opsAlertsTopic: databaseStack.opsAlertsTopic,
+});

--- a/infra/lib/db-stack.ts
+++ b/infra/lib/db-stack.ts
@@ -5,6 +5,11 @@ import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
 import * as rds from 'aws-cdk-lib/aws-rds';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as events from 'aws-cdk-lib/aws-events';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import * as cwActions from 'aws-cdk-lib/aws-cloudwatch-actions';
+import { Duration } from 'aws-cdk-lib';
 import { RdsScheduler } from './constructs/rds-scheduler';
 import { DbMigrations } from './constructs/db-migrations';
 
@@ -15,6 +20,7 @@ export interface DatabaseStackProps extends cdk.StackProps {
 
 export class DatabaseStack extends cdk.Stack {
   public readonly database: rds.DatabaseInstance;
+  public readonly opsAlertsTopic: sns.Topic;
 
   constructor(scope: Construct, id: string, props: DatabaseStackProps) {
     super(scope, id, props);
@@ -117,6 +123,58 @@ export class DatabaseStack extends cdk.Stack {
       dbName: 'skorify',
       database: this.database,
     });
+
+    // Tópico de alertas operativas. El ARN se publica en SSM para que el
+    // backend (repo aparte) enganche sus propias alarmas al mismo tópico.
+    this.opsAlertsTopic = new sns.Topic(this, 'OpsAlertsTopic', {
+      topicName: `skorify-${envName}-ops-alerts`,
+    });
+
+    const opsEmails = [
+      'jal.alejandro@gmail.com',
+      'santiagoloaizagiraldo@gmail.com',
+      'edisoncastrosanchez@gmail.com',
+      'awsugmanizales@gmail.com',
+    ];
+    for (const email of opsEmails) {
+      this.opsAlertsTopic.addSubscription(new subscriptions.EmailSubscription(email));
+    }
+
+    new ssm.StringParameter(this, 'OpsAlertsTopicArnParam', {
+      parameterName: `/skorify/${envName}/ops-alerts-topic-arn`,
+      stringValue: this.opsAlertsTopic.topicArn,
+      description: 'ARN del tópico SNS de alertas operativas',
+    });
+
+    const alertAction = new cwActions.SnsAction(this.opsAlertsTopic);
+
+    // Las t4g son burstables: con el balance de créditos en 0 la instancia
+    // queda limitada a su CPU base (ya pasó el 3 de junio de 2026 en dev).
+    const cpuCreditAlarm = new cloudwatch.Alarm(this, 'DbCpuCreditBalanceAlarm', {
+      metric: this.database.metric('CPUCreditBalance', {
+        period: Duration.minutes(15),
+        statistic: 'Minimum',
+      }),
+      threshold: 100,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      alarmDescription: 'Créditos de CPU de la RDS por agotarse — la instancia quedará limitada a su CPU base',
+    });
+    cpuCreditAlarm.addAlarmAction(alertAction);
+
+    // ~80% del max_connections aproximado de cada clase de instancia:
+    // t4g.small ~225 (dev), t4g.medium ~440 (prod).
+    const dbConnectionsAlarm = new cloudwatch.Alarm(this, 'DbConnectionsAlarm', {
+      metric: this.database.metricDatabaseConnections({
+        period: Duration.minutes(5),
+        statistic: 'Maximum',
+      }),
+      threshold: envName === 'prod' ? 350 : 180,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      alarmDescription: 'Conexiones a la RDS cerca del límite de la instancia',
+    });
+    dbConnectionsAlarm.addAlarmAction(alertAction);
 
     new cdk.CfnOutput(this, 'DBHost', {
       value: this.database.dbInstanceEndpointAddress,

--- a/infra/lib/match-processing-stack.ts
+++ b/infra/lib/match-processing-stack.ts
@@ -7,7 +7,9 @@ import * as sqs from "aws-cdk-lib/aws-sqs";
 import * as sources from "aws-cdk-lib/aws-lambda-event-sources";
 import * as ssm from "aws-cdk-lib/aws-ssm";
 import * as iam from "aws-cdk-lib/aws-iam";
+import * as sns from "aws-cdk-lib/aws-sns";
 import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import * as cwActions from "aws-cdk-lib/aws-cloudwatch-actions";
 import { Duration } from "aws-cdk-lib";
 import {
   EventSources,
@@ -25,6 +27,7 @@ export interface MatchProcessingStackProps extends cdk.StackProps {
   envName: string;
   vpcName: string;
   backendUrl: string;
+  opsAlertsTopic: sns.ITopic;
 }
 
 export class MatchProcessingStack extends cdk.Stack {
@@ -66,7 +69,7 @@ export class MatchProcessingStack extends cdk.Stack {
       retentionPeriod: Duration.days(14),
     });
 
-    new cloudwatch.Alarm(this, "DLQAlarm", {
+    const dlqAlarm = new cloudwatch.Alarm(this, "DLQAlarm", {
       metric: dlq.metricApproximateNumberOfMessagesVisible({
         period: Duration.minutes(5),
         statistic: "Sum",
@@ -77,6 +80,7 @@ export class MatchProcessingStack extends cdk.Stack {
         cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
       alarmDescription: "Mensajes en la DLQ — partidos que no pudieron procesarse",
     });
+    dlqAlarm.addAlarmAction(new cwActions.SnsAction(props.opsAlertsTopic));
 
     const createQueue = (name: string): sqs.Queue =>
       new sqs.Queue(this, name, {


### PR DESCRIPTION
## Qué cambia
- Tópico SNS `skorify-{env}-ops-alerts` con 4 suscriptores de correo (jal.alejandro, santiagoloaizagiraldo, edisoncastrosanchez, awsugmanizales — todos @gmail.com).
- ARN del tópico publicado en SSM (`/skorify/{env}/ops-alerts-topic-arn`) para que el backend enganche sus alarmas al mismo tópico (mismo patrón que `db-secret-arn`).
- Alarma **CPUCreditBalance < 100** (mínimo, 15 min): la t4g es burstable y en dev ya agotó créditos el 3 de junio — con balance 0 la BD queda limitada a su CPU base.
- Alarma **DatabaseConnections** > ~80% del límite por clase: 180 en dev (t4g.small ~225) y 350 en prod (t4g.medium ~440).
- La alarma de DLQ del flujo de partidos (existía sin destinatario) ahora notifica al tópico.

## Importante al desplegar
- **Cada correo recibirá un email de confirmación de SNS** — hay que hacer clic en *Confirm subscription* para empezar a recibir alertas.
- Este PR debe desplegarse **antes** que el PR de alarmas del backend (que leerá el parámetro SSM del tópico).

## Validación
- `tsc` compila; `cdk synth` de dev genera 1 tópico, 4 suscripciones, 2 alarmas nuevas y el parámetro SSM; el stack de event-bridge referencia el tópico en la alarma de DLQ.
- Post-deploy: `aws cloudwatch describe-alarms --alarm-name-prefix skorify-database` y enviar un mensaje de prueba al tópico con `aws sns publish`.